### PR TITLE
feat: add repo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An fzf wrapper around the GitHub CLI.
     - [`issue`](#issue)
     - [`pr`](#pr)
     - [`run`](#run)
+    - [`repo`](#repo)
   - [Configuration](#configuration)
   - [Related projects](#related-projects)
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,40 @@ that can be used with any `gh fzf` command:
     gh fzf r -b main -s failure
     ```
 
+### `repo`
+
+- **Usage**: `gh fzf repo [flags]`
+- **Aliases**: `repos`, `--repo`, `--repos`
+- **Flags**: See `gh repo list --help` for available options
+- **Keybindings**:
+  - `alt-i`: Run `gh fzf issue` on the selected repo
+    (see [`issue`](#issue))
+  - `alt-p`: Run `gh fzf pr` on the selected repo
+    (see [`pr`](#pr))
+  - `alt-r`: Run `gh fzf run` on the selected repo
+    (see [`run`](#run))
+  - `enter`: Edit the selected repo's settings
+    (see `gh repo edit --help`)
+  - `alt-C`: Clone the selected repo
+    (see `gh repo clone --help`)
+  - `alt-F`: Fork the selected repo
+    (see `gh repo fork --help`)
+  - `alt-c`: Filter the list, showing private repos
+  - `alt-o`: Filter the list, showing public repos
+  - `alt-f`: Filter the list, showing forked repos
+  - `alt-s`: Filter the list, showing source (non-forked) repos
+- **Examples**:
+  - Filter the initial list to non-archived, private repos created by you with
+    the "cli" topic:
+    ```sh
+    gh fzf repo --no-archived --visibility private --topic cli
+    ```
+  - Filter the initial list to archived repos created by the "google"
+    organization where the primary language was "typescript":
+    ```sh
+    gh fzf repo google --archived --language typescript
+    ```
+
 ## Configuration
 
 Environment variables are used to configure different options in `gh-fzf`.

--- a/gh-fzf
+++ b/gh-fzf
@@ -125,7 +125,7 @@ FZF_DEFAULT_OPTS='
 # --------------------------------------------------------------------- {|}
 
 default_cmd() {
-    FZF_DEFAULT_COMMAND="printf 'COMMAND\n%s\n%s\n%s\n' 'issue' 'pr' 'run'" \
+    FZF_DEFAULT_COMMAND="printf 'COMMAND\n%s\n%s\n%s\n%s\n' 'issue' 'pr' 'run' 'repo'" \
         fzf \
         --preview='GH_FORCE_TTY=$FZF_PREVIEW_COLUMNS gh help {}' \
         --preview-window='right:75%,wrap' \
@@ -345,6 +345,64 @@ Filters > (alt-f: failed runs) (alt-b: current branch) (alt-u: current user)
 }
 
 # --------------------------------------------------------------------- }}}
+# Command > repo                                                        {{{
+# --------------------------------------------------------------------- {|}
+
+repo_cmd() {
+    repo_template='\
+        --json "nameWithOwner,description,primaryLanguage,stargazerCount,forkCount,updatedAt,viewerPermission,visibility" \
+        --template '\''
+            {{- $headerColor := "blue+b" -}}
+            {{- tablerow
+                ("REPO" | autocolor $headerColor)
+                ("VISIBILITY" | autocolor $headerColor)
+                ("PERMISSIONS" | autocolor $headerColor)
+                ("LAST UPDATE" | autocolor $headerColor)
+                ("DESCRIPTION" | autocolor $headerColor)
+                ("STARS" | autocolor $headerColor)
+                ("FORKS" | autocolor $headerColor)
+            -}}
+
+            {{- range . -}}
+                {{- tablerow
+                    (.nameWithOwner | autocolor "white+h")
+                    (.visibility | autocolor "white+d")
+                    (.viewerPermission | autocolor "white+d")
+                    ((timeago .updatedAt) | autocolor "white+d")
+                    (truncate 100 (.description | autocolor "white+h"))
+                    (.stargazerCount | autocolor "white+d")
+                    (.forkCount | autocolor "white+h")
+                -}}
+            {{- end -}}
+    '\'''
+
+    repo_header='Actions > (enter: edit) (alt-c: clone) (alt-p: prs) (alt-i: issues) (alt-r: runs) (alt-f: fork) (alt-s: sync)
+        > (ctrl-o: open url) (ctrl-y: copy url) (ctrl-r: reload)
+Filters > (alt-P: private) (alt-O: public) (alt-S: source) (alt-F: forks)
+'
+
+    FZF_DEFAULT_COMMAND="GH_FORCE_TTY=$gh_columns gh repo list -L $GH_FZF_DEFAULT_LIMIT $*" \
+        fzf \
+        --preview='GH_FORCE_TTY=$FZF_PREVIEW_COLUMNS gh repo view {1}' \
+        --header="$repo_header" \
+        --header-lines=4 \
+        --bind="start:$on_start" \
+        --bind='ctrl-o:execute-silent(gh repo view --web {1})' \
+        --bind="ctrl-y:execute-silent(gh repo view {1} --json 'url' -q '.url' | $GH_FZF_COPY_CMD)" \
+        --bind='enter:execute(gh repo edit {1})' \
+        --bind='alt-c:execute(gh repo clone {1})' \
+        --bind="alt-p:execute(gh fzf pr --repo {1})" \
+        --bind="alt-i:execute(gh fzf issue --repo {1})" \
+        --bind="alt-r:execute(gh fzf run --repo {1})" \
+        --bind="alt-f:execute(gh repo fork {1})" \
+        --bind="alt-s:execute(gh repo sync {1})" \
+        --bind='alt-c:reload(eval "$FZF_DEFAULT_COMMAND --visibility private")' \
+        --bind='alt-o:reload(eval "$FZF_DEFAULT_COMMAND --visibility public")' \
+        --bind='alt-S:reload(eval "$FZF_DEFAULT_COMMAND --source")' \
+        --bind='alt-F:reload(eval "$FZF_DEFAULT_COMMAND --fork")'
+}
+
+# --------------------------------------------------------------------- }}}
 # Parse arguments                                                       {{{
 # --------------------------------------------------------------------- {|}
 
@@ -360,6 +418,7 @@ main() {
     case $command in
         h | -h | help | --help) help_cmd "$@" ;;
         r | -r | run | runs | --run | --runs) run_cmd "$@" ;;
+        R | -R | repo | repos | --repo | --repos) repo_cmd "$@" ;;
         p | -p | pr | prs | --pr | --prs) pr_cmd "$@" ;;
         i | -i | issue | issues | --issue | --issues) issue_cmd "$@" ;;
         v | V | -v | -V | version | --version) printf "%s\n" "$GH_FZF_VERSION" ;;

--- a/gh-fzf
+++ b/gh-fzf
@@ -50,15 +50,16 @@ Usage:
   gh fzf <command> [flags]
 
 Core Commands:
-  i, issue       Search for and interact with GitHub issues.
-  p, pr          Search for and interact with GitHub pull requests.
-  r, run         Search for and interact with GitHub Action runs.
+  issue       Search for and interact with GitHub issues.
+  pr          Search for and interact with GitHub pull requests.
+  run         Search for and interact with GitHub Action runs.
+  repo        Search for and interact with GitHub repos.
 
 See \`gh <command> list --help\` for the flag options.
 
 Other Commands:
-  h, help        Print this help message.
-  v, version     Print the version of gh-fzf.
+  help        Print this help message.
+  version     Print the version of gh-fzf.
 
 Check out the project homepage for more information, such as keybindings,
 configuration, and examples.
@@ -356,7 +357,7 @@ Filters > (alt-f: failed runs) (alt-b: current branch) (alt-u: current user)
 
 repo_cmd() {
     repo_template='\
-        --json "nameWithOwner,description,primaryLanguage,stargazerCount,forkCount,updatedAt,viewerPermission,visibility" \
+        --json "nameWithOwner,description,stargazerCount,forkCount,updatedAt,viewerPermission,visibility" \
         --template '\''
             {{- $headerColor := "blue+b" -}}
             {{- tablerow
@@ -373,7 +374,7 @@ repo_cmd() {
                 {{- tablerow
                     (.nameWithOwner | autocolor "white+h")
                     (.visibility | autocolor "white+d")
-                    (.viewerPermission | autocolor "white+d")
+                    (.viewerPermission | autocolor "white+h")
                     ((timeago .updatedAt) | autocolor "white+d")
                     (truncate 100 (.description | autocolor "white+h"))
                     (.stargazerCount | autocolor "white+d")
@@ -382,9 +383,9 @@ repo_cmd() {
             {{- end -}}
     '\'''
 
-    repo_header='Actions > (enter: edit) (alt-c: clone) (alt-p: prs) (alt-i: issues) (alt-r: runs) (alt-f: fork) (alt-s: sync)
+    repo_header='Actions > (enter: edit) (alt-p: prs) (alt-i: issues) (alt-r: runs) (alt-C: clone) (alt-F: fork)
         > (ctrl-o: open url) (ctrl-y: copy url) (ctrl-r: reload)
-Filters > (alt-P: private) (alt-O: public) (alt-S: source) (alt-F: forks)
+Filters > (alt-c: private) (alt-o: public) (alt-s: source) (alt-f: forks)
 '
 
     FZF_DEFAULT_COMMAND="GH_FORCE_TTY=$gh_columns gh repo list -L $GH_FZF_DEFAULT_LIMIT $*" \
@@ -395,17 +396,16 @@ Filters > (alt-P: private) (alt-O: public) (alt-S: source) (alt-F: forks)
         --bind="start:$on_start" \
         --bind='ctrl-o:execute-silent(gh repo view --web {1})' \
         --bind="ctrl-y:execute-silent(gh repo view {1} --json 'url' -q '.url' | $GH_FZF_COPY_CMD)" \
-        --bind='enter:execute(gh repo edit {1})' \
-        --bind='alt-c:execute(gh repo clone {1})' \
         --bind="alt-p:execute(gh fzf pr --repo {1})" \
         --bind="alt-i:execute(gh fzf issue --repo {1})" \
         --bind="alt-r:execute(gh fzf run --repo {1})" \
-        --bind="alt-f:execute(gh repo fork {1})" \
-        --bind="alt-s:execute(gh repo sync {1})" \
+        --bind='enter:execute(gh repo edit {1})' \
+        --bind='alt-C:execute(gh repo clone {1})' \
+        --bind="alt-F:execute(gh repo fork {1})" \
         --bind='alt-c:reload(eval "$FZF_DEFAULT_COMMAND --visibility private")' \
         --bind='alt-o:reload(eval "$FZF_DEFAULT_COMMAND --visibility public")' \
-        --bind='alt-S:reload(eval "$FZF_DEFAULT_COMMAND --source")' \
-        --bind='alt-F:reload(eval "$FZF_DEFAULT_COMMAND --fork")'
+        --bind='alt-s:reload(eval "$FZF_DEFAULT_COMMAND --source")' \
+        --bind='alt-f:reload(eval "$FZF_DEFAULT_COMMAND --fork")'
 }
 
 # --------------------------------------------------------------------- }}}
@@ -441,10 +441,10 @@ main() {
 
     case $command in
         h | -h | help | --help) help_cmd "$@" ;;
-        r | -r | run | runs | --run | --runs) run_cmd "$@" ;;
-        R | -R | repo | repos | --repo | --repos) repo_cmd "$@" ;;
-        p | -p | pr | prs | --pr | --prs) pr_cmd "$@" ;;
         i | -i | issue | issues | --issue | --issues) issue_cmd "$@" ;;
+        p | -p | pr | prs | --pr | --prs) pr_cmd "$@" ;;
+        r | -r | run | runs | --run | --runs) run_cmd "$@" ;;
+        repo | repos | --repo | --repos) repo_cmd "$@" ;;
         v | V | -v | -V | version | --version) printf "%s\n" "$GH_FZF_VERSION" ;;
         *) error "invalid command: \"$command\"" ;;
     esac

--- a/gh-fzf
+++ b/gh-fzf
@@ -356,32 +356,32 @@ Filters > (alt-f: failed runs) (alt-b: current branch) (alt-u: current user)
 # --------------------------------------------------------------------- {|}
 
 repo_cmd() {
-    repo_template='\
-        --json "nameWithOwner,description,stargazerCount,forkCount,updatedAt,viewerPermission,visibility" \
-        --template '\''
-            {{- $headerColor := "blue+b" -}}
-            {{- tablerow
-                ("REPO" | autocolor $headerColor)
-                ("VISIBILITY" | autocolor $headerColor)
-                ("PERMISSIONS" | autocolor $headerColor)
-                ("LAST UPDATE" | autocolor $headerColor)
-                ("DESCRIPTION" | autocolor $headerColor)
-                ("STARS" | autocolor $headerColor)
-                ("FORKS" | autocolor $headerColor)
-            -}}
+    # repo_template='\
+    #     --json "nameWithOwner,description,stargazerCount,forkCount,updatedAt,viewerPermission,visibility" \
+    #     --template '\''
+    #         {{- $headerColor := "blue+b" -}}
+    #         {{- tablerow
+    #             ("REPO" | autocolor $headerColor)
+    #             ("VISIBILITY" | autocolor $headerColor)
+    #             ("PERMISSIONS" | autocolor $headerColor)
+    #             ("LAST UPDATE" | autocolor $headerColor)
+    #             ("DESCRIPTION" | autocolor $headerColor)
+    #             ("STARS" | autocolor $headerColor)
+    #             ("FORKS" | autocolor $headerColor)
+    #         -}}
 
-            {{- range . -}}
-                {{- tablerow
-                    (.nameWithOwner | autocolor "white+h")
-                    (.visibility | autocolor "white+d")
-                    (.viewerPermission | autocolor "white+h")
-                    ((timeago .updatedAt) | autocolor "white+d")
-                    (truncate 100 (.description | autocolor "white+h"))
-                    (.stargazerCount | autocolor "white+d")
-                    (.forkCount | autocolor "white+h")
-                -}}
-            {{- end -}}
-    '\'''
+    #         {{- range . -}}
+    #             {{- tablerow
+    #                 (.nameWithOwner | autocolor "white+h")
+    #                 (.visibility | autocolor "white+d")
+    #                 (.viewerPermission | autocolor "white+h")
+    #                 ((timeago .updatedAt) | autocolor "white+d")
+    #                 (truncate 100 (.description | autocolor "white+h"))
+    #                 (.stargazerCount | autocolor "white+d")
+    #                 (.forkCount | autocolor "white+h")
+    #             -}}
+    #         {{- end -}}
+    # '\'''
 
     repo_header='Actions > (enter: edit) (alt-p: prs) (alt-i: issues) (alt-r: runs) (alt-C: clone) (alt-F: fork)
         > (ctrl-o: open url) (ctrl-y: copy url) (ctrl-r: reload)


### PR DESCRIPTION
Add command for finding repositories created by the current user or the user/organization specified via argument, if provided. See `gh repo list --help` for other options.


The `repo` command has keybindings for running the `issue`, `pr`, and `run` commands on the selected repository.