### PR TITLE
feat: add status command, display status during incidents

### DIFF
--- a/gh-fzf
+++ b/gh-fzf
@@ -150,7 +150,6 @@ export FZF_DEFAULT_OPTS='
 --no-hscroll --no-exit-0 --header-lines=1 --cycle --reverse --info=right
 --color="fg:#ebdbb2,fg+:#ebdbb2,bg:#282828,bg+:#3c3836,hl:#d3869b:bold,hl+:#d3869b"
 --color="info:#83a598,prompt:#bdae93,spinner:#fabd2f,pointer:#83a598,marker:#fe8019,header:#928374,label:#83a598"
---color="preview-scrollbar:#7c6f64,preview-border:#665c54,preview-label:#7c6f64"
 '${GH_STATUS:+--preview-label=\"$GH_STATUS\" --color=\"preview-label:#b57614,preview-border:#b57614\"}'
 --preview-window="right,wrap,<75(down,wrap)"
 --bind="alt-P:change-preview-window(down,70%,<75(down,70%,wrap)|hidden,<75(hidden)|)"

--- a/gh-fzf
+++ b/gh-fzf
@@ -34,6 +34,24 @@ GH_FZF_VERSION="v0.13.0" # x-release-please-version
 
 has() { command -v "$1" >/dev/null 2>&1; }
 
+github_status() {
+    GH_PAGER="cat" gh api https://www.githubstatus.com/api/v2/status.json --jq '
+    def colors: {
+        "green":      "'"$(tput setaf 2)"'",
+        "magenta":    "'"$(tput setaf 5)"'",
+        "yellow":     "'"$(tput setaf 3)"'",
+        "red":        "'"$(tput setaf 1)"'",
+        "reset":      "'"$(tput sgr0)"'"
+    };
+    def colored(text; color): colors[color] + text + colors.reset;
+    .status | (
+        if .indicator == "none" then colored(.description; "green")
+        elif .indicator == "minor" then colored(.description; "magenta")
+        elif .indicator == "major" then colored(.description; "yellow")
+        elif .indicator == "critical" then colored(.description; "red") end
+    )'
+}
+
 error() {
     if [ -n "$1" ]; then
         printf "Error: " >&2
@@ -1030,6 +1048,7 @@ main() {
         label | labels | --label | --labels) label_cmd "$@" ;;
         milestone | milestones | --milestone | --milestones) milestone_cmd "$@" ;;
         util | utils | --util | --utils) util_cmd "$@" ;;
+        status) github_status ;;
         changelog) gh fzf release --repo benelan/gh-fzf ;;
         upgrade) gh extension remove benelan/gh-fzf >/dev/null 2>&1 &&
             gh extension install benelan/gh-fzf --pin "stable" ;;

--- a/gh-fzf
+++ b/gh-fzf
@@ -35,21 +35,22 @@ GH_FZF_VERSION="v0.13.0" # x-release-please-version
 has() { command -v "$1" >/dev/null 2>&1; }
 
 github_status() {
-    GH_PAGER="cat" gh api https://www.githubstatus.com/api/v2/status.json --jq '
-    def colors: {
-        "green":      "'"$(tput setaf 2)"'",
-        "magenta":    "'"$(tput setaf 5)"'",
-        "yellow":     "'"$(tput setaf 3)"'",
-        "red":        "'"$(tput setaf 1)"'",
-        "reset":      "'"$(tput sgr0)"'"
-    };
-    def colored(text; color): colors[color] + text + colors.reset;
-    .status | (
-        if .indicator == "none" then colored(.description; "green")
-        elif .indicator == "minor" then colored(.description; "magenta")
-        elif .indicator == "major" then colored(.description; "yellow")
-        elif .indicator == "critical" then colored(.description; "red") end
-    )'
+    GH_PAGER="cat" gh api https://www.githubstatus.com/api/v2/status.json \
+        --jq '.status.description'
+    # 'def colors: {
+    #     "green":      "'"$(tput setaf 2)"'",
+    #     "magenta":    "'"$(tput setaf 5)"'",
+    #     "yellow":     "'"$(tput setaf 3)"'",
+    #     "red":        "'"$(tput setaf 1)"'",
+    #     "reset":      "'"$(tput sgr0)"'"
+    # };
+    # def colored(text; color): colors[color] + text + colors.reset;
+    # .status | (
+    #     if .indicator == "none" then colored(.description; "green")
+    #     elif .indicator == "minor" then colored(.description; "magenta")
+    #     elif .indicator == "major" then colored(.description; "yellow")
+    #     elif .indicator == "critical" then colored(.description; "red") end
+    # )'
 }
 
 error() {
@@ -139,13 +140,20 @@ else
     GH_COLUMNS='9999999'
 fi
 
+GH_STATUS="$(github_status)"
+[ "$GH_STATUS" == "All Systems Operational" ] && GH_STATUS="" ||
+    GH_STATUS=" GitHub Service Alert: $GH_STATUS "
+
 # The following fzf options are shared by all commands. They are prepended to
 # the FZF_DEFAULT_OPTS environment variable so they can be overridden by users.
 export FZF_DEFAULT_OPTS='
 --no-hscroll --no-exit-0 --header-lines=1 --cycle --reverse --info=right
---color "fg:#ebdbb2,fg+:#ebdbb2,bg:#282828,bg+:#3c3836,hl:#d3869b:bold,hl+:#d3869b,info:#83a598,prompt:#bdae93,spinner:#fabd2f,pointer:#83a598,marker:#fe8019,header:#928374,label:#83a598"
---preview-window="right,border-left,wrap,<75(down,border-top,wrap)"
---bind="alt-P:change-preview-window(down,70%,border-top,<75(down,70%,border-top,wrap)|hidden,<75(hidden)|)"
+--color="fg:#ebdbb2,fg+:#ebdbb2,bg:#282828,bg+:#3c3836,hl:#d3869b:bold,hl+:#d3869b"
+--color="info:#83a598,prompt:#bdae93,spinner:#fabd2f,pointer:#83a598,marker:#fe8019,header:#928374,label:#83a598"
+--color="preview-scrollbar:#7c6f64,preview-border:#665c54,preview-label:#7c6f64"
+'${GH_STATUS:+--preview-label=\"$GH_STATUS\" --color=\"preview-label:#b57614,preview-border:#b57614\"}'
+--preview-window="right,wrap,<75(down,wrap)"
+--bind="alt-P:change-preview-window(down,70%,<75(down,70%,wrap)|hidden,<75(hidden)|)"
 --bind="alt-H:toggle-header"
 --bind="ctrl-r:reload(eval \"$FZF_DEFAULT_COMMAND\")"
 --bind="alt-1:reload(eval \"$FZF_DEFAULT_COMMAND -L100\")"


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: add `status` command that prints GitHub's service [status](https://www.githubstatus.com/) summary
feat: display GitHub service alerts in the preview-label during incidents
END_COMMIT_OVERRIDE
