### PR TITLE
fix(status): prevent exit due to api request error

### DIFF
--- a/gh-fzf
+++ b/gh-fzf
@@ -36,7 +36,7 @@ has() { command -v "$1" >/dev/null 2>&1; }
 
 github_status() {
     GH_PAGER="cat" gh api https://www.githubstatus.com/api/v2/status.json \
-        --jq '.status.description'
+        --cache '10m' --jq '.status.description'
     # 'def colors: {
     #     "green":      "'"$(tput setaf 2)"'",
     #     "magenta":    "'"$(tput setaf 5)"'",
@@ -149,9 +149,10 @@ fi
 # set shell so bash features can be used in subshells created by fzf
 export SHELL="bash"
 
-GH_STATUS="$(github_status)"
-[ "$GH_STATUS" == "All Systems Operational" ] && GH_STATUS="" ||
-    GH_STATUS=" GitHub Service Alert: $GH_STATUS "
+GH_STATUS="$(github_status || true)"
+if [ -n "$GH_STATUS" ] && [ "$GH_STATUS" != "All Systems Operational" ]; then
+    GH_STATUS_INDICATOR=" $GH_STATUS - githubstatus.com "
+fi
 
 # The following fzf options are shared by all commands. They are prepended to
 # the FZF_DEFAULT_OPTS environment variable so they can be overridden by users.
@@ -159,7 +160,7 @@ export FZF_DEFAULT_OPTS='
 --no-hscroll --no-exit-0 --header-lines=1 --cycle --reverse --info=right
 --color="fg:#ebdbb2,fg+:#ebdbb2,bg:#282828,bg+:#3c3836,hl:#d3869b:bold,hl+:#d3869b"
 --color="info:#83a598,prompt:#bdae93,spinner:#fabd2f,pointer:#83a598,marker:#fe8019,header:#928374,label:#83a598"
-'${GH_STATUS:+--preview-label=\"$GH_STATUS\" --color=\"preview-label:#b57614,preview-border:#b57614\"}'
+'${GH_STATUS_INDICATOR:+--preview-label=\"$GH_STATUS_INDICATOR\" --color=\"preview-label:#b57614,preview-border:#b57614\"}'
 --preview-window="right,wrap,<75(down,wrap)"
 --bind="alt-P:change-preview-window(down,70%,<75(down,70%,wrap)|hidden,<75(hidden)|)"
 --bind="alt-H:toggle-header"
@@ -1064,7 +1065,7 @@ main() {
         label | labels | --label | --labels) label_cmd "$@" ;;
         milestone | milestones | --milestone | --milestones) milestone_cmd "$@" ;;
         util | utils | --util | --utils) util_cmd "$@" ;;
-        status) github_status ;;
+        status) echo "$GH_STATUS" ;;
         changelog) gh fzf release --repo benelan/gh-fzf ;;
         upgrade)
             latest_version=$(gh release view --json tagName --jq .tagName --repo benelan/gh-fzf)


### PR DESCRIPTION
- Prevent gh-fzf from exiting if errors occur when fetching status info
- Cache status response for 10min
- Remove redundant request to githubstatus.com
