### PR TITLE
feat: add global help key to view command's readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,29 +29,29 @@ An fzf wrapper around the GitHub CLI.
 
    - **Homebrew**
 
-     ```sh
-     brew install gh fzf
-     ```
+   ```sh
+   brew install gh fzf
+   ```
 
    - **DNF**
 
-     ```sh
-     sudo dnf install gh fzf
-     ```
+   ```sh
+   sudo dnf install gh fzf
+   ```
 
    - ... see the links above for other package managers
 
 2. Authenticate with the GitHub CLI:
 
-   ```sh
-   gh auth login
-   ```
+```bash
+gh auth login
+```
 
 3. Install this extension:
 
-   ```sh
-   gh extension install benelan/gh-fzf
-   ```
+```sh
+gh extension install benelan/gh-fzf
+```
 
 4. **[???](#usage)**
 
@@ -61,7 +61,7 @@ An fzf wrapper around the GitHub CLI.
 
 To upgrade `gh-fzf` to the latest commit on `main`:
 
-```sh
+```shell
 gh extension upgrade gh-fzf
 ```
 
@@ -133,15 +133,15 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to open and closed issues assigned to you in the "v1.33.7" milestone:
 
-    ```sh
-    gh fzf issue --assignee @me --milestone "v1.33.7" --state all
-    ```
+  ```sh
+  gh fzf issue --assignee @me --milestone "v1.33.7" --state all
+  ```
 
   - Filter the initial list to issues with the "good first issue" label, no assignee, and in the "backburner" milestone. Uses [GitHub's search syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests):
 
-    ```sh
-    gh fzf i -S \'no:assignee label:\"good first issue\" milestone:backburner\'
-    ```
+  ```sh
+  gh fzf i -S \'no:assignee label:\"good first issue\" milestone:backburner\'
+  ```
 
 ### `pr`
 
@@ -177,15 +177,15 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to your merged pull requests with the "breaking change" label:
 
-    ```sh
-    gh fzf pr --state merged --author @me --label \"breaking change\"
-    ```
+  ```sh
+  gh fzf pr --state merged --author @me --label \"breaking change\"
+  ```
 
   - Filter the initial list to your pull requests merged since the beginning of 2023 that have "breaking change" in the body. Uses [GitHub's search syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests):
 
-    ```sh
-    gh fzf p -S \'merged:">=2023-01-01" \"breaking change\" in:body author:@me\'
-    ```
+  ```sh
+  gh fzf p -S \'merged:">=2023-01-01" \"breaking change\" in:body author:@me\'
+  ```
 
 ### `run`
 
@@ -217,15 +217,15 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to runs for the "tests" workflow:
 
-    ```sh
-    gh fzf run --workflow tests
-    ```
+  ```sh
+  gh fzf run --workflow tests
+  ```
 
   - Filter the initial list to failed runs on the main branch:
 
-    ```sh
-    gh fzf r -b main -s failure
-    ```
+  ```sh
+  gh fzf r -b main -s failure
+  ```
 
 [^1]:
     The supported notification tools (in order of precedence) are `dunstify`, `notify-send`, and `osascript`. The notification has [actions](https://dunst-project.org/documentation#ACTIONS) for "view logs" and "open in browser" when using `dunstify`. There is an additional "download artifacts" or "rerun failed jobs" action depending on whether the run passed or failed, respectively.
@@ -254,9 +254,9 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to show all workflows:
 
-    ```sh
-    gh fzf workflow --all
-    ```
+  ```sh
+  gh fzf workflow --all
+  ```
 
 ### `release`
 
@@ -280,9 +280,9 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to exclude drafts and prereleases:
 
-    ```sh
-    gh fzf release --exclude-drafts --exclude-prereleases
-    ```
+  ```sh
+  gh fzf release --exclude-drafts --exclude-prereleases
+  ```
 
 ### `label`
 
@@ -308,9 +308,9 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to sort by label name in descending order
 
-    ```sh
-    gh fzf label --sort name --order desc
-    ```
+  ```sh
+  gh fzf label --sort name --order desc
+  ```
 
 ### `milestone`
 
@@ -361,15 +361,15 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to your non-archived, private repos with the "cli" topic:
 
-    ```sh
-    gh fzf repo --no-archived --visibility private --topic cli
-    ```
+  ```sh
+  gh fzf repo --no-archived --visibility private --topic cli
+  ```
 
   - Filter the initial list to archived repos created by the "google" organization where the primary language was "typescript":
 
-    ```sh
-    gh fzf repo google --archived --language typescript
-    ```
+  ```sh
+  gh fzf repo google --archived --language typescript
+  ```
 
 ### `gist`
 
@@ -393,9 +393,9 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to only show public gists (excluding secret ones):
 
-    ```sh
-    gh fzf gist --public
-    ```
+  ```sh
+  gh fzf gist --public
+  ```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ gh fzf changelog
 ## Usage
 
 ```sh
-gh fzf \<command\> [flags]
+gh fzf <command> [flags]
 ```
 
 This extension adds a new command that wraps GitHub's `list` subcommands with fzf to make them fuzzy findable. All of the arguments after `<command>` are passed directly to `gh`. Because of the way shell works, you need to escape quotes required by GitHub, e.g. [strings with whitespace](https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#use-quotation-marks-for-queries-with-whitespace). There are usage examples for each command in the sections below.

--- a/README.md
+++ b/README.md
@@ -244,14 +244,10 @@ There are also global keybindings that work on all `gh-fzf` commands:
     gh fzf r -b main -s failure
     ```
 
-<!--prettier-ignore-start-->
-
 [^1]:
-    The supported notification tools (in order of precedence) are `dunstify`, `notify-send`, and `osascript`.
-    The notification has [actions](https://dunst-project.org/documentation#ACTIONS) for "view logs" and "open in browser" when using `dunstify`. There is an additional "download artifacts" or "rerun failed jobs" action depending on whether the run passed or failed, respectively.
-    > **NOTE:** The run watcher process is executed in the background, so closing `gh-fzf` won't prevent the desktop notification from displaying. Use `pkill -f "gh run watch --exit-status"` to terminate the run watcher.
+    The supported notification tools (in order of precedence) are `dunstify`, `notify-send`, and `osascript`. The notification has [actions](https://dunst-project.org/documentation#ACTIONS) for "view logs" and "open in browser" when using `dunstify`. There is an additional "download artifacts" or "rerun failed jobs" action depending on whether the run passed or failed, respectively.
 
-<!--prettier-ignore-end-->
+    > **NOTE:** The run watcher process is executed in the background, so closing `gh-fzf` won't prevent the desktop notification from displaying. Use `pkill -f "gh run watch --exit-status"` to terminate the run watcher.
 
 ### `workflow`
 

--- a/README.md
+++ b/README.md
@@ -247,9 +247,9 @@ There are also global keybindings that work on all `gh-fzf` commands:
 <!--prettier-ignore-start-->
 
 [^1]:
-  The supported notification tools (in order of precedence) are `dunstify`, `notify-send`, and `osascript`.
-  The notification has [actions](https://dunst-project.org/documentation#ACTIONS) for "view logs" and "open in browser" when using `dunstify`. There is an additional "download artifacts" or "rerun failed jobs" action depending on whether the run passed or failed, respectively.
-  > **NOTE:** The run watcher process is executed in the background, so closing `gh-fzf` won't prevent the desktop notification from displaying. Use `pkill -f "gh run watch --exit-status"` to terminate the run watcher.
+    The supported notification tools (in order of precedence) are `dunstify`, `notify-send`, and `osascript`.
+    The notification has [actions](https://dunst-project.org/documentation#ACTIONS) for "view logs" and "open in browser" when using `dunstify`. There is an additional "download artifacts" or "rerun failed jobs" action depending on whether the run passed or failed, respectively.
+    > **NOTE:** The run watcher process is executed in the background, so closing `gh-fzf` won't prevent the desktop notification from displaying. Use `pkill -f "gh run watch --exit-status"` to terminate the run watcher.
 
 <!--prettier-ignore-end-->
 

--- a/README.md
+++ b/README.md
@@ -244,12 +244,14 @@ There are also global keybindings that work on all `gh-fzf` commands:
     gh fzf r -b main -s failure
     ```
 
+<!--prettier-ignore-start-->
+
 [^1]:
-    The supported notification tools (in order of precedence) are `dunstify`, `notify-send`, and `osascript`.
+  The supported notification tools (in order of precedence) are `dunstify`, `notify-send`, and `osascript`.
+  The notification has [actions](https://dunst-project.org/documentation#ACTIONS) for "view logs" and "open in browser" when using `dunstify`. There is an additional "download artifacts" or "rerun failed jobs" action depending on whether the run passed or failed, respectively.
+  > **NOTE:** The run watcher process is executed in the background, so closing `gh-fzf` won't prevent the desktop notification from displaying. Use `pkill -f "gh run watch --exit-status"` to terminate the run watcher.
 
-    The notification has [actions](https://dunst-project.org/documentation#ACTIONS) for "view logs" and "open in browser" when using `dunstify`. There is an additional "download artifacts" or "rerun failed jobs" action depending on whether the run passed or failed, respectively.
-
-    > **NOTE:** The run watcher process is executed in the background, so closing `gh-fzf` won't prevent the desktop notification from displaying. Use `pkill -f "gh run watch --exit-status"` to terminate the run watcher.
+<!--prettier-ignore-end-->
 
 ### `workflow`
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ An fzf wrapper around the GitHub CLI.
 
 ## Installation
 
-1. Install [`gh`](https://github.com/cli/cli#installation) and
-   [`fzf`](https://github.com/junegunn/fzf#installation) if you don't already
-   have them. For example:
+1. Install [`gh`](https://github.com/cli/cli#installation) and [`fzf`](https://github.com/junegunn/fzf#installation) if you don't already have them. For example:
 
    - **Homebrew**
 
@@ -67,8 +65,7 @@ To upgrade `gh-fzf` to the latest commit on `main`:
 gh extension upgrade gh-fzf
 ```
 
-Alternatively, you can pin a tag when installing `gh` extensions. A convenience
-command is provided for upgrading to the latest version **(recommended)**:
+Alternatively, you can pin a tag when installing `gh` extensions. A convenience command is provided for upgrading to the latest version **(recommended)**:
 
 ```sh
 gh fzf upgrade
@@ -80,8 +77,7 @@ You can check which version of `gh-fzf` you currently have installed:
 gh fzf version
 ```
 
-The [changelog](./CHANGELOG.md) contains a list of features and fixes released
-in each version. You can also view the release notes via `gh-fzf` itself:
+The [changelog](./CHANGELOG.md) contains a list of features and fixes released in each version. You can also view the release notes via `gh-fzf` itself:
 
 ```sh
 gh fzf changelog
@@ -93,17 +89,9 @@ gh fzf changelog
 gh fzf \<command\> [flags]
 ```
 
-This extension adds a new command that wraps GitHub's `list` subcommands with
-fzf to make them fuzzy findable. All of the arguments after `<command>` are
-passed directly to `gh`. Because of the way shell works, you need to escape
-quotes required by GitHub, e.g.
-[strings with whitespace](https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#use-quotation-marks-for-queries-with-whitespace).
-There are usage examples for each command in the sections below.
+This extension adds a new command that wraps GitHub's `list` subcommands with fzf to make them fuzzy findable. All of the arguments after `<command>` are passed directly to `gh`. Because of the way shell works, you need to escape quotes required by GitHub, e.g. [strings with whitespace](https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#use-quotation-marks-for-queries-with-whitespace). There are usage examples for each command in the sections below.
 
-A preview of the current selection is displayed when navigating through the
-resulting list. Each command has keybindings that execute `gh` subcommands on
-the item or filter the list further. The command-specific keybindings are
-listed in the following sections.
+A preview of the current selection is displayed when navigating through the resulting list. Each command has keybindings that execute `gh` subcommands on the item or filter the list further. The command-specific keybindings are listed in the following sections.
 
 There are also global keybindings that work on all `gh-fzf` commands:
 
@@ -143,15 +131,13 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
 - **Examples:**
 
-  - Filter the initial list to open and closed issues assigned to you in the
-    "v1.33.7" milestone:
+  - Filter the initial list to open and closed issues assigned to you in the "v1.33.7" milestone:
 
     ```sh
     gh fzf issue --assignee @me --milestone "v1.33.7" --state all
     ```
 
-  - Filter the initial list to issues with the "good first issue" label, no
-    assignee, and in the "backburner" milestone. Uses [GitHub's search syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests):
+  - Filter the initial list to issues with the "good first issue" label, no assignee, and in the "backburner" milestone. Uses [GitHub's search syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests):
 
     ```sh
     gh fzf i -S \'no:assignee label:\"good first issue\" milestone:backburner\'
@@ -189,16 +175,13 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
 - **Examples:**
 
-  - Filter the initial list to your merged pull requests with the
-    "breaking change" label:
+  - Filter the initial list to your merged pull requests with the "breaking change" label:
 
     ```sh
     gh fzf pr --state merged --author @me --label \"breaking change\"
     ```
 
-  - Filter the initial list to your pull requests merged since the beginning
-    of 2023 that have "breaking change" in the body. Uses
-    [GitHub's search syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests):
+  - Filter the initial list to your pull requests merged since the beginning of 2023 that have "breaking change" in the body. Uses [GitHub's search syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests):
 
     ```sh
     gh fzf p -S \'merged:">=2023-01-01" \"breaking change\" in:body author:@me\'
@@ -376,15 +359,13 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
 - **Examples**:
 
-  - Filter the initial list to your non-archived, private repos with the "cli"
-    topic:
+  - Filter the initial list to your non-archived, private repos with the "cli" topic:
 
     ```sh
     gh fzf repo --no-archived --visibility private --topic cli
     ```
 
-  - Filter the initial list to archived repos created by the "google"
-    organization where the primary language was "typescript":
+  - Filter the initial list to archived repos created by the "google" organization where the primary language was "typescript":
 
     ```sh
     gh fzf repo google --archived --language typescript
@@ -433,13 +414,9 @@ Environment variables are used to configure `gh-fzf`.
 [commit message]: https://github.com/benelan/gh-fzf/commit/f6f78e2dce617f17c6048f28f568fbdc57895119
 [see code]: https://github.com/benelan/gh-fzf/blob/65bfdb81a30fc55878e04758e5cbcec68a242a18/gh-fzf#L113-L125
 
-You can also set the
-[`FZF_DEFAULT_OPTS`](https://github.com/junegunn/fzf/blob/master/README.md#environment-variables)
-environment variable to add/change `fzf` options used by `gh-fzf` commands.
+You can also set the [`FZF_DEFAULT_OPTS`](https://github.com/junegunn/fzf/blob/master/README.md#environment-variables) environment variable to add/change `fzf` options used by `gh-fzf` commands.
 
-For example, create aliases in the `gh` config file that add new keybindings to
-the [`issue`](#issue), [`pr`](#pr), [`run`](#run), and [`milestone`](#milestone)
-commands:
+For example, create aliases in the `gh` config file that add new keybindings to the [`issue`](#issue), [`pr`](#pr), [`run`](#run), and [`milestone`](#milestone) commands:
 
 ```yml
 # ~/.config/gh/config.yml
@@ -487,30 +464,20 @@ When adding or modifying fzf keybindings:
   - the `<workflow-id>` for the [`workflow`](#workflow) command
   - the `<number>` for the [`milestone`](#milestone) command
 
-Check out the `gh-fzf` author's
-[`~/.config/gh/config.yml`](https://github.com/benelan/dotfiles/blob/master/.config/gh/config.yml)
-for more inspiration.
+Check out the `gh-fzf` author's [`~/.config/gh/config.yml`](https://github.com/benelan/dotfiles/blob/master/.config/gh/config.yml) for more inspiration.
 
-See the
-[code](https://github.com/benelan/gh-fzf/blob/65bfdb81a30fc55878e04758e5cbcec68a242a18/gh-fzf#L157-L179)
-for the list of fzf options shared by all `gh-fzf` commands.
+See the [code](https://github.com/benelan/gh-fzf/blob/65bfdb81a30fc55878e04758e5cbcec68a242a18/gh-fzf#L157-L179) for the list of fzf options shared by all `gh-fzf` commands.
 
 > [!WARNING]
-> If any of the shared keybindings set by `gh-fzf` don't work, you may be
-> overriding them in your shell's start up scripts (e.g. `~/.bashrc`) by setting
-> the `$FZF_DEFAULT_OPTS` environment variable.
+> If any of the shared keybindings set by `gh-fzf` don't work, you may be overriding them in your shell's start up scripts (e.g. `~/.bashrc`) by setting the `$FZF_DEFAULT_OPTS` environment variable.
 
 ## Related projects
 
-There is another `fzf` wrapper around `gh` that also provides some `git`
-functionality. However, it doesn't provide as many `gh` commands, keybindings,
-or configuration options.
+There is another `fzf` wrapper around `gh` that also provides some `git` functionality. However, it doesn't provide as many `gh` commands, keybindings, or configuration options.
 
 - [`gh-f`](https://github.com/gennaro-tedesco/gh-f)
 
-The main focus of `gh-fzf` is providing keybindings to run `gh` subcommands on
-the selected item, so `git` functionality is left to other tools. The
-following `fzf` wrappers around `git` are good options to bridge that gap.
+The main focus of `gh-fzf` is providing keybindings to run `gh` subcommands on the selected item, so `git` functionality is left to other tools. The following `fzf` wrappers around `git` are good options to bridge that gap.
 
 - [`forgit`](https://github.com/wfxr/forgit)
 - [`git-fuzzy`](https://github.com/bigH/git-fuzzy)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ There are also global keybindings that work on all `gh-fzf` commands:
 | `ctrl-o`          | Open the selected item in the browser                                     | `GH_FZF_OPEN_KEY`                  |
 | `ctrl-y`          | Copy the selected item's URL to the clipboard                             | `GH_FZF_COPY_KEY`                  |
 | `ctrl-r`          | Reload the list to its initial filter state and fetch changes from GitHub | `GH_FZF_RELOAD_KEY`                |
-| `alt-?`           | View the current command's README section from the terminal               | `GH_FZF_HELP_KEY`                  |
+| `alt-?`           | View the current command's readme section from the terminal               | `GH_FZF_HELP_KEY`                  |
 | `alt-P`           | Toggle the preview window layout from default, bottom, and hidden         | `GH_FZF_TOGGLE_PREVIEW_KEY`        |
 | `alt-H`           | Toggle displaying the header, where the keybinding hints are located      | `GH_FZF_TOGGLE_HINTS_KEY`          |
 | `alt-1` - `alt-9` | Change the number of items fetched from GitHub to 100, 200, ..., 900      | N/A                                |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ There are also global keybindings that work on all `gh-fzf` commands:
 | `ctrl-o`          | Open the selected item in the browser                                     | `GH_FZF_OPEN_KEY`                  |
 | `ctrl-y`          | Copy the selected item's URL to the clipboard                             | `GH_FZF_COPY_KEY`                  |
 | `ctrl-r`          | Reload the list to its initial filter state and fetch changes from GitHub | `GH_FZF_RELOAD_KEY`                |
+| `alt-?`           | View the current command's README section from the terminal               | `GH_FZF_HELP_KEY`                  |
 | `alt-P`           | Toggle the preview window layout from default, bottom, and hidden         | `GH_FZF_TOGGLE_PREVIEW_KEY`        |
 | `alt-H`           | Toggle displaying the header, where the keybinding hints are located      | `GH_FZF_TOGGLE_HINTS_KEY`          |
 | `alt-1` - `alt-9` | Change the number of items fetched from GitHub to 100, 200, ..., 900      | N/A                                |

--- a/README.md
+++ b/README.md
@@ -29,29 +29,29 @@ An fzf wrapper around the GitHub CLI.
 
    - **Homebrew**
 
-   ```sh
-   brew install gh fzf
-   ```
+     ```sh
+     brew install gh fzf
+     ```
 
    - **DNF**
 
-   ```sh
-   sudo dnf install gh fzf
-   ```
+     ```sh
+     sudo dnf install gh fzf
+     ```
 
    - ... see the links above for other package managers
 
 2. Authenticate with the GitHub CLI:
 
-```bash
-gh auth login
-```
+   ```sh
+   gh auth login
+   ```
 
 3. Install this extension:
 
-```sh
-gh extension install benelan/gh-fzf
-```
+   ```sh
+   gh extension install benelan/gh-fzf
+   ```
 
 4. **[???](#usage)**
 
@@ -61,7 +61,7 @@ gh extension install benelan/gh-fzf
 
 To upgrade `gh-fzf` to the latest commit on `main`:
 
-```shell
+```sh
 gh extension upgrade gh-fzf
 ```
 
@@ -133,15 +133,15 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to open and closed issues assigned to you in the "v1.33.7" milestone:
 
-  ```sh
-  gh fzf issue --assignee @me --milestone "v1.33.7" --state all
-  ```
+    ```sh
+    gh fzf issue --assignee @me --milestone "v1.33.7" --state all
+    ```
 
   - Filter the initial list to issues with the "good first issue" label, no assignee, and in the "backburner" milestone. Uses [GitHub's search syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests):
 
-  ```sh
-  gh fzf i -S \'no:assignee label:\"good first issue\" milestone:backburner\'
-  ```
+    ```sh
+    gh fzf i -S \'no:assignee label:\"good first issue\" milestone:backburner\'
+    ```
 
 ### `pr`
 
@@ -177,15 +177,15 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to your merged pull requests with the "breaking change" label:
 
-  ```sh
-  gh fzf pr --state merged --author @me --label \"breaking change\"
-  ```
+    ```sh
+    gh fzf pr --state merged --author @me --label \"breaking change\"
+    ```
 
   - Filter the initial list to your pull requests merged since the beginning of 2023 that have "breaking change" in the body. Uses [GitHub's search syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests):
 
-  ```sh
-  gh fzf p -S \'merged:">=2023-01-01" \"breaking change\" in:body author:@me\'
-  ```
+    ```sh
+    gh fzf p -S \'merged:">=2023-01-01" \"breaking change\" in:body author:@me\'
+    ```
 
 ### `run`
 
@@ -217,15 +217,15 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to runs for the "tests" workflow:
 
-  ```sh
-  gh fzf run --workflow tests
-  ```
+    ```sh
+    gh fzf run --workflow tests
+    ```
 
   - Filter the initial list to failed runs on the main branch:
 
-  ```sh
-  gh fzf r -b main -s failure
-  ```
+    ```sh
+    gh fzf r -b main -s failure
+    ```
 
 [^1]:
     The supported notification tools (in order of precedence) are `dunstify`, `notify-send`, and `osascript`. The notification has [actions](https://dunst-project.org/documentation#ACTIONS) for "view logs" and "open in browser" when using `dunstify`. There is an additional "download artifacts" or "rerun failed jobs" action depending on whether the run passed or failed, respectively.
@@ -254,9 +254,9 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to show all workflows:
 
-  ```sh
-  gh fzf workflow --all
-  ```
+    ```sh
+    gh fzf workflow --all
+    ```
 
 ### `release`
 
@@ -280,9 +280,9 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to exclude drafts and prereleases:
 
-  ```sh
-  gh fzf release --exclude-drafts --exclude-prereleases
-  ```
+    ```sh
+    gh fzf release --exclude-drafts --exclude-prereleases
+    ```
 
 ### `label`
 
@@ -308,9 +308,9 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to sort by label name in descending order
 
-  ```sh
-  gh fzf label --sort name --order desc
-  ```
+    ```sh
+    gh fzf label --sort name --order desc
+    ```
 
 ### `milestone`
 
@@ -361,15 +361,15 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to your non-archived, private repos with the "cli" topic:
 
-  ```sh
-  gh fzf repo --no-archived --visibility private --topic cli
-  ```
+    ```sh
+    gh fzf repo --no-archived --visibility private --topic cli
+    ```
 
   - Filter the initial list to archived repos created by the "google" organization where the primary language was "typescript":
 
-  ```sh
-  gh fzf repo google --archived --language typescript
-  ```
+    ```sh
+    gh fzf repo google --archived --language typescript
+    ```
 
 ### `gist`
 
@@ -393,9 +393,9 @@ There are also global keybindings that work on all `gh-fzf` commands:
 
   - Filter the initial list to only show public gists (excluding secret ones):
 
-  ```sh
-  gh fzf gist --public
-  ```
+    ```sh
+    gh fzf gist --public
+    ```
 
 ## Configuration
 

--- a/gh-fzf
+++ b/gh-fzf
@@ -156,7 +156,7 @@ fi
 export GH_FZF_RELOAD_KEY="${GH_FZF_RELOAD_KEY:-ctrl-r}"
 export GH_FZF_OPEN_KEY="${GH_FZF_OPEN_KEY:-ctrl-o}"
 export GH_FZF_COPY_KEY="${GH_FZF_COPY_KEY:-ctrl-y}"
-export GH_FZF_HELP_KEY="${GH_FZF_COPY_KEY:-alt-?}"
+export GH_FZF_HELP_KEY="${GH_FZF_HELP_KEY:-alt-?}"
 export GH_FZF_TOGGLE_HINTS_KEY="${GH_FZF_TOGGLE_HINTS_KEY:-alt-H}"
 export GH_FZF_TOGGLE_PREVIEW_KEY="${GH_FZF_TOGGLE_PREVIEW_KEY:-alt-P}"
 

--- a/gh-fzf
+++ b/gh-fzf
@@ -156,10 +156,11 @@ fi
 export GH_FZF_RELOAD_KEY="${GH_FZF_RELOAD_KEY:-ctrl-r}"
 export GH_FZF_OPEN_KEY="${GH_FZF_OPEN_KEY:-ctrl-o}"
 export GH_FZF_COPY_KEY="${GH_FZF_COPY_KEY:-ctrl-y}"
+export GH_FZF_HELP_KEY="${GH_FZF_COPY_KEY:-alt-?}"
 export GH_FZF_TOGGLE_HINTS_KEY="${GH_FZF_TOGGLE_HINTS_KEY:-alt-H}"
 export GH_FZF_TOGGLE_PREVIEW_KEY="${GH_FZF_TOGGLE_PREVIEW_KEY:-alt-P}"
 
-global_binds="Globals > ($GH_FZF_OPEN_KEY: open url) ($GH_FZF_COPY_KEY: copy url) ($GH_FZF_RELOAD_KEY: reload) ($GH_FZF_TOGGLE_PREVIEW_KEY: toggle preview) ($GH_FZF_TOGGLE_HINTS_KEY: toggle hints) (alt-1: 100 items) (alt-2: 200 items) (...) (alt-9: 900 items)"
+global_binds="Globals > ($GH_FZF_OPEN_KEY: open url) ($GH_FZF_COPY_KEY: copy url) ($GH_FZF_RELOAD_KEY: reload) ($GH_FZF_HELP_KEY: help) ($GH_FZF_TOGGLE_PREVIEW_KEY: toggle preview) ($GH_FZF_TOGGLE_HINTS_KEY: toggle hints) (alt-1: 100 items) (alt-2: 200 items) (...) (alt-9: 900 items)"
 
 # The following fzf options are shared by all commands. They are prepended to
 # the FZF_DEFAULT_OPTS environment variable so they can be overridden by users.
@@ -201,7 +202,8 @@ default_cmd() {
             GH_FORCE_TTY=$((FZF_PREVIEW_COLUMNS-3)) gh help $cmd
         ' \
         --preview-window='right:75%,wrap' \
-        --bind="enter:execute(gh fzf {})"
+        --bind="enter:execute(gh fzf {})" \
+        --bind="$GH_FZF_HELP_KEY:execute(GH_PAGER='less -p \"^  ### .{}\"' gh repo view benelan/gh-fzf)"
 }
 
 # ----------------------------------------------------------------------1}}}
@@ -275,6 +277,7 @@ $global_binds
         --bind="start:${GH_FZF_HIDE_HINTS:+"toggle-header"}" \
         --bind="$GH_FZF_OPEN_KEY:execute-silent(gh issue view --web {1} &)+refresh-preview" \
         --bind="$GH_FZF_COPY_KEY:execute-silent(gh fzf util copy-url issue {1})+refresh-preview" \
+        --bind="$GH_FZF_HELP_KEY:execute(GH_PAGER='less -p \"^  ### .issue\"' gh repo view benelan/gh-fzf)" \
         --bind="$GH_FZF_ISSUE_EDIT_KEY:execute(gh issue edit {1})+refresh-preview" \
         --bind="$GH_FZF_ISSUE_COMMENT_KEY:execute(gh issue comment {1})+refresh-preview" \
         --bind="$GH_FZF_ISSUE_CHECKOUT_KEY:become(gh fzf util develop-issue {1})" \
@@ -380,6 +383,7 @@ $global_binds
         --bind="start:${GH_FZF_HIDE_HINTS:+"toggle-header"}" \
         --bind="$GH_FZF_OPEN_KEY:execute-silent(gh pr view --web {1} &)+refresh-preview" \
         --bind="$GH_FZF_COPY_KEY:execute-silent(gh fzf util copy-url pr {1})+refresh-preview" \
+        --bind="$GH_FZF_HELP_KEY:execute(GH_PAGER='less -p \"^  ### .pr\"' gh repo view benelan/gh-fzf)" \
         --bind="$GH_FZF_PR_COPY_BRANCH_KEY:execute-silent(
             gh pr view --json 'headRefName' -q '.headRefName' {1} | $GH_FZF_COPY_CMD
         )+refresh-preview" \
@@ -488,6 +492,7 @@ $global_binds
         --bind="start:${GH_FZF_HIDE_HINTS:+"toggle-header"}" \
         --bind="$GH_FZF_OPEN_KEY:execute-silent(gh run view --web {-1} &)+refresh-preview" \
         --bind="$GH_FZF_COPY_KEY:execute-silent(gh fzf util copy-url run {-1})+refresh-preview" \
+        --bind="$GH_FZF_HELP_KEY:execute(GH_PAGER='less -p \"^  ### .run\"' gh repo view benelan/gh-fzf)" \
         --bind="$GH_FZF_RUN_VIEW_KEY:execute(
             case {1} in
                 in_progress | queued | requested | waiting) gh run watch {-1} ;;
@@ -568,6 +573,7 @@ $global_binds
         --bind="start:${GH_FZF_HIDE_HINTS:+"toggle-header"}" \
         --bind="$GH_FZF_OPEN_KEY:execute-silent(gh workflow view --web {-1} &)+refresh-preview" \
         --bind="$GH_FZF_COPY_KEY:execute-silent(gh browse --no-browser {-2} | $GH_FZF_COPY_CMD)+refresh-preview" \
+        --bind="$GH_FZF_HELP_KEY:execute(GH_PAGER='less -p \"^  ### .workflow\"' gh repo view benelan/gh-fzf)" \
         --bind="$GH_FZF_WORKFLOW_VIEW_RUNS_KEY:execute(gh fzf run --workflow {-1})+refresh-preview" \
         --bind="$GH_FZF_WORKFLOW_DISPATCH_KEY:execute(gh workflow run {-1})+refresh-preview" \
         --bind="$GH_FZF_WORKFLOW_ENABLE_KEY:execute(gh workflow enable {-1})+refresh-preview" \
@@ -640,6 +646,7 @@ $global_binds
         --bind="start:${GH_FZF_HIDE_HINTS:+"toggle-header"}" \
         --bind="$GH_FZF_OPEN_KEY:execute-silent(gh release view --web {1} &)+refresh-preview" \
         --bind="$GH_FZF_COPY_KEY:execute-silent(gh fzf util copy-url release {1})+refresh-preview" \
+        --bind="$GH_FZF_HELP_KEY:execute(GH_PAGER='less -p \"^  ### .release\"' gh repo view benelan/gh-fzf)" \
         --bind="$GH_FZF_RELEASE_DOWNLOAD_KEY:execute(gh release download {1})+refresh-preview" \
         --bind="$GH_FZF_RELEASE_DELETE_KEY:execute(gh release delete {1})+refresh-preview" \
         --bind="$GH_FZF_RELEASE_STABLE_FILTER_KEY"':reload(eval "$FZF_DEFAULT_COMMAND --exclude-pre-releases")' \
@@ -678,6 +685,7 @@ $global_binds
         --header="$label_header" \
         --bind="start:${GH_FZF_HIDE_HINTS:+"toggle-header"}" \
         --bind="$GH_FZF_OPEN_KEY:execute-silent(gh label list --web &)" \
+        --bind="$GH_FZF_HELP_KEY:execute(GH_PAGER='less -p \"^  ### .label\"' gh repo view benelan/gh-fzf)" \
         --bind="$GH_FZF_LABEL_PRINT_KEY:become(printf '%s\n' {+} | awk -F'  ' '{print \$1}')" \
         --bind="$GH_FZF_LABEL_EDIT_NAME_KEY"':execute(
             read -rp "Enter new name for {1} label: " name </dev/tty >/dev/tty 2>&1;
@@ -778,6 +786,7 @@ Globals > ($GH_FZF_OPEN_KEY: open url) ($GH_FZF_COPY_KEY: copy url) ($GH_FZF_REL
                 /repos/{owner}/{repo}/milestones/{-1})\"
             [ -n \"\$url\" ] && $GH_FZF_OPEN_CMD \"\$url\" &
         )" \
+        --bind="$GH_FZF_HELP_KEY:execute(GH_PAGER='less -p \"^  ### .milestone\"' gh repo view benelan/gh-fzf)" \
         --bind="$GH_FZF_MILESTONE_PRINT_KEY:become(echo {1})" \
         --bind="$GH_FZF_MILESTONE_VIEW_ISSUES_KEY:execute(gh fzf issue --milestone {-1})" \
         --bind="$GH_FZF_MILESTONE_CLOSE_KEY"':execute(
@@ -883,6 +892,7 @@ $global_binds
         --bind="start:${GH_FZF_HIDE_HINTS:+"toggle-header"}" \
         --bind="$GH_FZF_OPEN_KEY:execute-silent(gh repo view --web {1} &)+refresh-preview" \
         --bind="$GH_FZF_COPY_KEY:execute-silent(gh fzf util copy-url repo {1})+refresh-preview" \
+        --bind="$GH_FZF_HELP_KEY:execute(GH_PAGER='less -p \"^  ### .repo\"' gh repo view benelan/gh-fzf)" \
         --bind="$GH_FZF_REPO_EDIT_KEY:execute(gh repo edit {1})+refresh-preview" \
         --bind="$GH_FZF_REPO_VIEW_ISSUES_KEY:execute(gh fzf issue --repo {1})+refresh-preview" \
         --bind="$GH_FZF_REPO_VIEW_PRS_KEY:execute(gh fzf pr --repo {1})+refresh-preview" \
@@ -926,6 +936,7 @@ Filters > ($GH_FZF_GIST_PUBLIC_FILTER_KEY: public) ($GH_FZF_GIST_SECRET_FILTER_K
         --bind="$GH_FZF_COPY_KEY:execute-silent(
             echo https://gist.github.com/$(gh api user -q .login)/{1} | $GH_FZF_COPY_CMD
         )+refresh-preview" \
+        --bind="$GH_FZF_HELP_KEY:execute(GH_PAGER='less -p \"^  ### .gist\"' gh repo view benelan/gh-fzf)" \
         --bind="$GH_FZF_GIST_EDIT_KEY:execute(gh gist edit {1})+refresh-preview" \
         --bind="$GH_FZF_GIST_CLONE_KEY:execute(gh gist clone {1})+refresh-preview" \
         --bind="$GH_FZF_GIST_DELETE_KEY:execute(gh gist delete {1})+refresh-preview" \


### PR DESCRIPTION
The new key opens the `gh-fzf` readme in `less` and scrolls to the current command's section. The readme's markdown is formatted via [glow], which `gh repo view` uses under the hood. The key is bound to `alt-?` by default, but you can modify it using the `GH_FZF_HELP_KEY` environment variable.

This PR also removes hard line wraps from the readme because they looked funky in [glow].

[glow]: https://github.com/charmbracelet/glow
